### PR TITLE
[MAZE-0015] add Maze::getRandomUnvisitedNeighboringPointUnsafe method

### DIFF
--- a/include/engine/Maze.hh
+++ b/include/engine/Maze.hh
@@ -59,6 +59,25 @@ namespace miroslavbel_maze_game_gdi {
              */
             void bitwiseOrAssignment_Unsafe(MazePointMut& point, mazeCell::MazeCell cell) noexcept;
 
+            /*!
+             * \brief Случайным образом выбирает соседнюю еще непосещенную
+             * генератором клетку.
+             * 
+             * Если такой клетки не существует, то вернет \a false. Иначе
+             * вернет \a true и запишет в \a point координаты найденной
+             * клетки, а также запишет в старую клетку информацию о направление
+             * движения.
+             * 
+             * \note Как генератор псевдослучайных чисел использует
+             * \a std::rand. А значит, хорошо бы чтоб \a std::srand уже была
+             * вызвана.
+             * 
+             * \param[in,out] point валидная точка
+             * 
+             * \return удалось ли найти соседнюю еще непосещенную клетку
+             */
+            bool getRandomUnvisitedNeighboringPointUnsafe(MazePointMut& point) noexcept;
+
          public:
 
             /*!

--- a/include/engine/MazeCell.hh
+++ b/include/engine/MazeCell.hh
@@ -86,7 +86,7 @@ namespace miroslavbel_maze_game_gdi {
           * 
           * \return посетил ли генератор эту клетку
           */
-         inline bool isNotVisited(MazeCell cell) noexcept;
+         bool isNotVisited(MazeCell cell) noexcept;
 
       } // namespace mazeCell
 

--- a/src/engine/Maze.cpp
+++ b/src/engine/Maze.cpp
@@ -23,6 +23,69 @@ namespace miroslavbel_maze_game_gdi {
          this->mazeData[static_cast<uint16_t>(this->size.getWidth()) * static_cast<uint16_t>(point.getY()) + point.getX()] |= cell;
       }
 
+      bool Maze::getRandomUnvisitedNeighboringPointUnsafe(MazePointMut& point) noexcept {
+         const int numberOfDirection = 4;
+         int numberOfParticipant = 0;
+         // TOP, RIGHT, BOTTOM, LEFT
+         bool isInCompetition[numberOfDirection] = {false, false, false, false};
+         // TOP
+         if (point.getY() < this->size.getHeight() - 1 && mazeCell::isNotVisited(this->getCellUnsafe(point.getX(), point.getY() + 1))) {
+            isInCompetition[0] = true;
+            ++numberOfParticipant;
+         }
+         // RIGHT
+         if (point.getX() < this->size.getWidth() - 1 && mazeCell::isNotVisited(this->getCellUnsafe(point.getX() + 1, point.getY()))) {
+            isInCompetition[1] = true;
+            ++numberOfParticipant;
+         }
+         // BOTTOM
+         if (point.getY() != 0 && mazeCell::isNotVisited(this->getCellUnsafe(point.getX(), point.getY() - 1))) {
+            isInCompetition[2] = true;
+            ++numberOfParticipant;
+         }
+         // LEFT
+         if (point.getX() != 0 && mazeCell::isNotVisited(this->getCellUnsafe(point.getX() - 1, point.getY()))) {
+            isInCompetition[3] = true;
+            ++numberOfParticipant;
+         }
+         if (numberOfParticipant == 0) {
+            return false;
+         }
+         int random = std::rand() % numberOfParticipant;
+         int indexOfTrues = 0;
+         int randomDirection = 0;
+         for (int randomDirection = 0; randomDirection < numberOfDirection; ++randomDirection) {
+            if (isInCompetition[randomDirection]) {
+               if (random == indexOfTrues) {
+                  break;
+               } else {
+                  ++indexOfTrues;
+               }
+            }
+         }
+         switch (randomDirection) {
+            case 0: // TOP
+               this->bitwiseOrAssignment_Unsafe(point, mazeCell::VISITED_FROM_BOTTOM);
+               point.setY( point.getY() + 1 );
+               break;
+            case 1: // RIGHT
+               this->bitwiseOrAssignment_Unsafe(point, mazeCell::VISITED_FROM_LEFT);
+               point.setX( point.getX() + 1 );
+               break;
+            case 2: // BOTTOM
+               this->bitwiseOrAssignment_Unsafe(point, mazeCell::VISITED_FROM_TOP);
+               point.setY( point.getY() - 1 );
+               break;
+            case 3: // LEFT
+               this->bitwiseOrAssignment_Unsafe(point, mazeCell::VISITED_FROM_RIGHT);
+               point.setX( point.getX() - 1 );
+               break;
+            default:
+               break;
+         }
+         return true;
+      }
+
       Maze::~Maze() {
          delete this->mazeData;
       }

--- a/src/engine/MazeCell.cpp
+++ b/src/engine/MazeCell.cpp
@@ -6,7 +6,7 @@ namespace miroslavbel_maze_game_gdi {
 
       namespace mazeCell {
 
-         inline bool isNotVisited(MazeCell cell) noexcept {
+         bool isNotVisited(MazeCell cell) noexcept {
             return cell >> 4 == 0 ? true : false;
          }
 


### PR DESCRIPTION
 - Add `Maze::getRandomUnvisitedNeighboringPointUnsafe` method to `engine::Maze`
 - Remove `inline` specifier for `engine::mazeCell::isNotVisited` function